### PR TITLE
Inline hash function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
-.PHONY: all gofmt test vet lint install
+.PHONY: all gofmt test bench prof vet lint install
 
 all: gofmt test vet lint install
 
 test:
 	go test
+
+bench:
+	go test -run=XXX -bench=. -cpu=1,4 -benchmem
+
+prof:
+	go test -run=XXX -bench=. -test.cpuprofile=cpu.out
+	go tool pprof shredis.test cpu.out
+
+mem:
+	go test -run=XXX -bench=. -test.memprofile=mem.out
+	go tool pprof -alloc_objects shredis.test mem.out
 
 gofmt:
 	find . -name \*.go|xargs gofmt -w

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,45 @@
+package shredis
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Benchmark(b *testing.B) {
+	sh := New(map[string]string{
+		"shard0": "localhost:6379",
+		"shard1": "localhost:6379",
+		"shard2": "localhost:6379",
+		"shard3": "localhost:6379",
+	})
+
+	b.ResetTimer()
+	work := prepareWork(100, 0.5)
+	for i := 0; i < b.N; i++ {
+		doWork(b, sh, work)
+	}
+}
+
+func prepareWork(n int, write float64) []*Cmd {
+	var cmds []*Cmd
+	writeN := int(float64(n) * write)
+	readN := n - writeN
+	for i := 0; i < writeN; i++ {
+		key := fmt.Sprintf("key%d", i)
+		cmds = append(cmds, Build(key, "HSET", key, "aap", "noot"))
+	}
+	for i := 0; i < readN; i++ {
+		key := fmt.Sprintf("key%d", i)
+		cmds = append(cmds, Build(key, "HGET", key, "aap"))
+	}
+	return cmds
+}
+
+func doWork(b *testing.B, sh *Shred, work []*Cmd) {
+	sh.Exec(work...)
+	for _, w := range work {
+		if _, err := w.Get(); err != nil {
+			b.Error(err)
+		}
+	}
+}

--- a/ketama.go
+++ b/ketama.go
@@ -16,7 +16,6 @@ package shredis
 import (
 	"crypto/md5"
 	"fmt"
-	"hash/fnv"
 	"sort"
 )
 
@@ -42,10 +41,19 @@ func md5Digest(in string) []byte {
 	return h.Sum(nil)
 }
 
+// inline the FNV64a hash. Taken from stdlib: hash/fnv/fnv.go
+const (
+	offset64 uint64 = 14695981039346656037
+	prime64         = 1099511628211
+)
+
 func hashKey(in []byte) uint {
-	h := fnv.New64a()
-	h.Write(in)
-	return uint(uint32(h.Sum64()))
+	hash := offset64
+	for _, c := range in {
+		hash ^= uint64(c)
+		hash *= prime64
+	}
+	return uint(uint32(hash))
 }
 
 func ketamaNew(buckets []bucket) continuum {


### PR DESCRIPTION
Inline the fvn64a function, which saves allocating the interface.

The benchmark goes from 267allocs/op to 167allocs/op