### PR TITLE
Lazy payload building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ language: go
 install: go get -t
 
 script: make test
+
+sudo: false
+
+go:
+    - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ script: make test
 sudo: false
 
 go:
-    - tip
+    - 1.5.2

--- a/bench_test.go
+++ b/bench_test.go
@@ -56,3 +56,26 @@ func BenchmarkBuilding(b *testing.B) {
 		Build("key1", "HSET", "key1", "aap", "noot")
 	}
 }
+
+func BenchmarkNoPrepare(b *testing.B) {
+	sh := New(map[string]string{
+		"shard0": "localhost:6379",
+		"shard1": "localhost:6379",
+		"shard2": "localhost:6379",
+		"shard3": "localhost:6379",
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cmds := []*Cmd{
+			Build("key", "HSET", "key", "aap", "noot"),
+			Build("key", "HGET", "key", "aap"),
+		}
+		sh.Exec(cmds...)
+		for _, c := range cmds {
+			if _, err := c.Get(); err != nil {
+				b.Error(err)
+			}
+		}
+	}
+}

--- a/command.go
+++ b/command.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 )
 
 var (
@@ -34,27 +33,6 @@ func Build(key string, fields ...string) *Cmd {
 		fields: fields,
 		err:    ErrNotExecuted,
 	}
-}
-
-var poolCmds = sync.Pool{
-	New: func() interface{} {
-		return &Cmd{}
-	},
-}
-
-// PooledBuild is same as Build, but uses a sync.Pool. Use Cmd.Put() to put
-// them back in the queue.
-func PooledBuild(key string, fields ...string) *Cmd {
-	c := poolCmds.Get().(*Cmd)
-	c.hash = hashKey(key)
-	c.payload = buildCommand(fields, c.payload[:0])
-	c.err = ErrNotExecuted
-	return c
-}
-
-// Put puts a cmd back in the pool for reuse.
-func (c *Cmd) Put() {
-	poolCmds.Put(c)
 }
 
 // Get returns redis' result.

--- a/command.go
+++ b/command.go
@@ -18,10 +18,10 @@ var (
 
 // Cmd is a redis command.
 type Cmd struct {
-	hash    uint64
-	payload []byte
-	res     interface{}
-	err     error
+	hash   uint64
+	fields []string
+	res    interface{}
+	err    error
 }
 
 // Build makes a command which will be send to the shard for 'key'. All
@@ -30,9 +30,9 @@ type Cmd struct {
 // simple command->reply ('WATCH').
 func Build(key string, fields ...string) *Cmd {
 	return &Cmd{
-		hash:    hashKey(key),
-		payload: buildCommand(fields, make([]byte, 0, 64)),
-		err:     ErrNotExecuted,
+		hash:   hashKey(key),
+		fields: fields,
+		err:    ErrNotExecuted,
 	}
 }
 
@@ -237,7 +237,7 @@ func resInt(x interface{}) (int, error) {
 	}
 }
 
-func buildCommand(fields []string, b []byte) []byte {
+func appendCommand(fields []string, b []byte) []byte {
 	b = append(b, '*')
 	b = strconv.AppendInt(b, int64(len(fields)), 10)
 	b = append(b, '\r', '\n')

--- a/command_test.go
+++ b/command_test.go
@@ -1,7 +1,6 @@
 package shredis
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 )
@@ -11,13 +10,13 @@ func TestCommand(t *testing.T) {
 		{
 			have: Build("k", "GET", "k"),
 			want: &Cmd{
-				hash:    2248277386,
-				payload: []byte("*2\r\n$3\r\nGET\r\n$1\r\nk\r\n"),
+				hash:   2248277386,
+				fields: []string{"GET", "k"},
 			},
 		},
 	} {
-		if !bytes.Equal(c.have.payload, c.want.payload) {
-			t.Errorf("have: %q, want: %q", c.have.payload, c.want.payload)
+		if !reflect.DeepEqual(c.have.fields, c.want.fields) {
+			t.Errorf("have: %v, want: %v", c.have.fields, c.want.fields)
 		}
 		if c.have.hash != c.want.hash {
 			t.Errorf("have: %v, want: %v", c.have.hash, c.want.hash)

--- a/reader.go
+++ b/reader.go
@@ -62,29 +62,31 @@ func (r *replyReader) readInt() (int, error) {
 		negate = false
 		n      = 0
 	)
-loop:
 	for i := 0; ; i++ {
 		c, err := r.buf.ReadByte()
 		if err != nil {
 			return 0, err
 		}
 		switch {
+
 		case c >= '0' && c <= '9':
 			n = n*10 + int(c-'0')
+
 		case i == 0 && c == '-':
 			negate = true
+
 		case c == '\r':
-			break loop
+			r.buf.ReadByte() // flush the \n
+			if negate {
+				n *= -1
+			}
+			return n, nil
+
 		default:
 			return 0, ErrProtocolError
+
 		}
 	}
-	r.buf.ReadByte() // flush the \n
-
-	if negate {
-		n *= -1
-	}
-	return n, nil
 }
 
 func (r *replyReader) simpleString() (string, error) {

--- a/redis_test.go
+++ b/redis_test.go
@@ -1,7 +1,7 @@
 package shredis
 
 import (
-	"bytes"
+	"reflect"
 	"testing"
 	"time"
 
@@ -40,52 +40,52 @@ func TestGet(t *testing.T) {
 
 func TestBuilds(t *testing.T) {
 	for _, c := range []struct {
-		have    *Cmd
-		key     string
-		payload []string
+		have   *Cmd
+		key    string
+		fields []string
 	}{
 		{
-			have:    BuildGet("foo"),
-			key:     "foo",
-			payload: []string{"GET", "foo"},
+			have:   BuildGet("foo"),
+			key:    "foo",
+			fields: []string{"GET", "foo"},
 		},
 		{
-			have:    BuildSet("aap", "noot"),
-			key:     "aap",
-			payload: []string{"SET", "aap", "noot"},
+			have:   BuildSet("aap", "noot"),
+			key:    "aap",
+			fields: []string{"SET", "aap", "noot"},
 		},
 		{
-			have:    BuildSetEx("aap", "noot", 7500*time.Millisecond),
-			key:     "aap",
-			payload: []string{"SET", "aap", "noot", "EX", "7"},
+			have:   BuildSetEx("aap", "noot", 7500*time.Millisecond),
+			key:    "aap",
+			fields: []string{"SET", "aap", "noot", "EX", "7"},
 		},
 		{
-			have:    BuildSetNx("aap", "noot"),
-			key:     "aap",
-			payload: []string{"SETNX", "aap", "noot"},
+			have:   BuildSetNx("aap", "noot"),
+			key:    "aap",
+			fields: []string{"SETNX", "aap", "noot"},
 		},
 		{
-			have:    BuildSetNxEx("aap", "noot", 7500*time.Millisecond),
-			key:     "aap",
-			payload: []string{"SET", "aap", "noot", "NX", "EX", "7"},
+			have:   BuildSetNxEx("aap", "noot", 7500*time.Millisecond),
+			key:    "aap",
+			fields: []string{"SET", "aap", "noot", "NX", "EX", "7"},
 		},
 		{
-			have:    BuildExpire("aap", 7500*time.Millisecond),
-			key:     "aap",
-			payload: []string{"EXPIRE", "aap", "7"},
+			have:   BuildExpire("aap", 7500*time.Millisecond),
+			key:    "aap",
+			fields: []string{"EXPIRE", "aap", "7"},
 		},
 		{
-			have:    BuildTTL("aap"),
-			key:     "aap",
-			payload: []string{"TTL", "aap"},
+			have:   BuildTTL("aap"),
+			key:    "aap",
+			fields: []string{"TTL", "aap"},
 		},
 	} {
 		want := &Cmd{
-			hash:    hashKey(c.key),
-			payload: buildCommand(c.payload, nil),
+			hash:   hashKey(c.key),
+			fields: c.fields,
 		}
-		if !bytes.Equal(c.have.payload, want.payload) {
-			t.Errorf("have: %q, want: %q", c.have.payload, want.payload)
+		if !reflect.DeepEqual(c.have.fields, want.fields) {
+			t.Errorf("have: %q, want: %q", c.have.fields, want.fields)
 		}
 		if c.have.hash != want.hash {
 			t.Errorf("have: %v, want: %v", c.have.hash, want.hash)

--- a/shredis.go
+++ b/shredis.go
@@ -140,8 +140,8 @@ func (s *Shred) MapExec(fields ...string) map[string]*Cmd {
 		wg.Add(1)
 		cmd := &Cmd{
 			// no key
-			payload: buildCommand(fields, nil),
-			err:     ErrNotExecuted,
+			fields: fields,
+			err:    ErrNotExecuted,
 		}
 		cmds[shard.label] = cmd
 		shard.conn.exec([]action{


### PR DESCRIPTION
*Building benchmarks are better since we don't build the payload anymore, and Benchmark is slower since we now build the payload every run.

```
benchmark                old ns/op     new ns/op     delta
Benchmark                263837        303927        +15.19%
Benchmark-4              309077        296358        -4.12%
BenchmarkBuilding        423           205           -51.54%
BenchmarkBuilding-4      399           182           -54.39%
BenchmarkNoPrepare       29304         28059         -4.25%
BenchmarkNoPrepare-4     41190         29235         -29.02%

benchmark                old allocs     new allocs     delta
Benchmark                318            318            +0.00%
Benchmark-4              318            318            +0.00%
BenchmarkBuilding        2              2              +0.00%
BenchmarkBuilding-4      2              2              +0.00%
BenchmarkNoPrepare       11             11             +0.00%
BenchmarkNoPrepare-4     11             11             +0.00%

benchmark                old bytes     new bytes     delta
Benchmark                14161         14165         +0.03%
Benchmark-4              14161         14172         +0.08%
BenchmarkBuilding        128           128           +0.00%
BenchmarkBuilding-4      128           128           +0.00%
BenchmarkNoPrepare       448           432           -3.57%
BenchmarkNoPrepare-4     448           432           -3.57%
```